### PR TITLE
add customization flexibility, stereo projection + inverse, improve / fix global example 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IndividualDisplacements"
 uuid = "b92f0c32-5b7e-11e9-1d7b-238b2da8b0e6"
 authors = ["gaelforget <gforget@mit.edu>"]
-version = "0.2.10"
+version = "0.2.11"
 
 [deps]
 CFTime = "179af706-886a-5703-950a-314cd64e0468"

--- a/examples/flow_fields.jl
+++ b/examples/flow_fields.jl
@@ -97,7 +97,7 @@ function global_ocean_circulation(;k=1,ny=2)
   Γ=merge(Γ,Dict("update_location!" => func))
 
   #initialize u0,u1 etc
-  𝑃,𝐷=set_up_𝑃(k,0.0,Γ,ECCOclim_path);
+  𝑃,𝐷=set_up_FlowFields(k,Γ,ECCOclim_path);
 
   #add parameters for use in reset!
   tmp=(frac=r_reset, Γ=Γ)

--- a/examples/helper_functions.jl
+++ b/examples/helper_functions.jl
@@ -13,8 +13,8 @@ function init_global_randn(np ::Int , 𝑃::NamedTuple)
     (lon, lat) = randn_lonlat(maximum([2*np 10]))
     (_,_,_,_,f,x,y)=InterpolationFactors(𝑃.Γ,lon,lat)
     m=findall(f.!==0)
-    m=findall(nearest_to_xy(𝑃.msk,x[m],y[m],f[m]).==1.0)[1:np]
-    return permutedims([x[m] y[m] f[m]])
+    n=findall(nearest_to_xy(𝑃.msk,x[m],y[m],f[m]).==1.0)[1:np]
+    return permutedims([x[m[n]] y[m[n]] f[m[n]]])
 end
 
 """
@@ -30,6 +30,16 @@ function reset_lonlat!(𝐼::Individuals,𝐷::NamedTuple)
     k_reset = rand(1:np, n_reset)
     v0 = permutedims([v0[:,i] for i in 1:size(v0,2)])
     𝐼.📌[k_reset].=v0[1:n_reset]
+    isempty(𝐼.🔴.ID) ? m=maximum(𝐼.🆔) : m=max(maximum(𝐼.🔴.ID),maximum(𝐼.🆔))
+    𝐼.🆔[k_reset]=collect(1:n_reset) .+ m
+end
+
+function reset_xy!(𝐼::Individuals,𝐷::NamedTuple)
+    np=length(𝐼.🆔)
+    n_reset = Int(round(𝐷.frac*np))
+    k_reset = rand(1:np, n_reset)
+    l_reset = rand(1:np, n_reset)
+    𝐼.📌[k_reset]=permutedims([xy[:,l_reset[i]] for i in 1:n_reset])
     isempty(𝐼.🔴.ID) ? m=maximum(𝐼.🆔) : m=max(maximum(𝐼.🔴.ID),maximum(𝐼.🆔))
     𝐼.🆔[k_reset]=collect(1:n_reset) .+ m
 end

--- a/examples/helper_functions.jl
+++ b/examples/helper_functions.jl
@@ -72,17 +72,14 @@ end
 """
     set_up_𝑃(k::Int,t::Float64,Γ::Dict,pth::String)
 
-Define the `𝑃` _parameter_ tuple given grid variables `Γ`, vertical level
-choice `k`, time `t` in `seconds`, and velocity fields obtained from
-files in `pth`.
-
-The two climatological months (`m0`,`m1`) that bracket time `t` are
-read to memory (e.g. months 12 & 1 then 1 & 2 and so on).
-
-_Note: the initial implementation approximates every month duration
-to 365 days / 12 months for simplicity._
+Define `FlowFields` data structure (𝑃) along with ancillary variables (𝐷)
+for the specified grid (`Γ` dictionnary), vertical level (`k`), and 
+file location (`pth`).
+    
+_Note: the initial implementation approximates month durations to 
+365 days / 12 months for simplicity and sets 𝑃.𝑇 to [-mon/2,mon/2]_
 """
-function set_up_𝑃(k::Int,t::Float64,Γ::Dict,pth::String)
+function set_up_FlowFields(k::Int,Γ::Dict,pth::String)
     XC=exchange(Γ["XC"]) #add 1 lon point at each edge
     YC=exchange(Γ["YC"]) #add 1 lat point at each edge
     iDXC=1. ./Γ["DXC"]
@@ -91,7 +88,7 @@ function set_up_𝑃(k::Int,t::Float64,Γ::Dict,pth::String)
     mon=86400.0*365.0/12.0
     func=Γ["update_location!"]
     
-    𝐷 = (🔄 = update_𝑃!, pth=pth,
+    𝐷 = (🔄 = update_FlowFields!, pth=pth,
          XC=XC, YC=YC, iDXC=iDXC, iDYC=iDYC,
          k=k, msk=Γ["hFacC"][:, k])
 
@@ -101,21 +98,20 @@ function set_up_𝑃(k::Int,t::Float64,Γ::Dict,pth::String)
     𝑃=𝐹_MeshArray2D{Float64}(MeshArray(γ,Float64),MeshArray(γ,Float64),
     MeshArray(γ,Float64),MeshArray(γ,Float64),[-mon/2,mon/2],func)
 
-    𝐷.🔄(𝑃,𝐷,0.0)
-
     return 𝑃,𝐷
 end
 
 """
-    update_𝑃!(𝑃::Union{NamedTuple,FlowFields},t::Float64)
+    update_FlowFields!(𝑃::FlowFields,𝐷::NamedTuple,t::Float64)
 
-Update input data (velocity arrays) and time period (array) inside 𝑃 (𝑃.u0[:], etc, and 𝑃.𝑇[:])
-based on the chosen time `t` (in `seconds`). 
+Update flow field arrays (in 𝑃), 𝑃.𝑇, and ancillary variables (in 𝐷) 
+according to the chosen time `t` (in `seconds`). 
 
-_Note: for now, it is assumed that (1) input 𝑃.𝑇 is used to infer `dt` between consecutive velocity fields,
-(2) periodicity of 12 monthly records, (3) vertical 𝑃.k is selected -- but this could easily be generalized._ 
+_Note: for now, it is assumed that (1) the time interval `dt` between 
+consecutive records is diff(𝑃.𝑇), (2) monthly climatologies are used 
+with a periodicity of 12 months, (3) vertical 𝑃.k is selected_
 """
-function update_𝑃!(𝑃::Union{NamedTuple,FlowFields},𝐷::NamedTuple,t::Float64)
+function update_FlowFields!(𝑃::FlowFields,𝐷::NamedTuple,t::Float64)
     dt=𝑃.𝑇[2]-𝑃.𝑇[1]
 
     m0=Int(floor((t+dt/2.0)/dt))

--- a/examples/helper_functions.jl
+++ b/examples/helper_functions.jl
@@ -183,7 +183,7 @@ function update_FlowFields!(𝑃::𝐹_MeshArray3D,𝐷::NamedTuple,t::Float64)
     (U,V)=read_velocities(𝑃.u0.grid,m1,𝐷.pth)
     u1=U; v1=V
     u1[findall(isnan.(u1))]=0.0; v1[findall(isnan.(v1))]=0.0 #mask with 0s rather than NaNs
-    for k=1:50
+    for k=1:nr
         u1[:,k]=u1[:,k].*𝐷.iDXC; v1[:,k]=v1[:,k].*𝐷.iDYC; #normalize to grid units
         (tmpu,tmpv)=exchange(u1[:,k],v1[:,k],1) #add 1 point at each edge for u and v
         u1[:,k]=tmpu

--- a/examples/worldwide/global_ocean_circulation.jl
+++ b/examples/worldwide/global_ocean_circulation.jl
@@ -23,16 +23,24 @@
 using IndividualDisplacements, DataFrames, Statistics, CSV
 
 include(joinpath(dirname(pathof(IndividualDisplacements)),"../examples/helper_functions.jl"))
-IndividualDisplacements.get_ecco_velocity_if_needed();
+
+IndividualDisplacements.get_ecco_variable_if_needed("UVELMASS");
+IndividualDisplacements.get_ecco_variable_if_needed("VVELMASS");
+IndividualDisplacements.get_ecco_variable_if_needed("WVELMASS");
+IndividualDisplacements.get_ecco_variable_if_needed("THETA");
+IndividualDisplacements.get_ecco_variable_if_needed("SALT");
 
 #nb # %% {"slideshow": {"slide_type": "subslide"}, "cell_type": "markdown"}
 # ## 2. Set Up Parameters & Inputs
 #
-# - select vertical level & duration in years
-# - read grid variables & velocities
-# - normalize velocities
+# - select vertical level (k=1 by default; k=0 for 3D) & duration in years (ny=2 by default)
+# - read grid variables
+# - return FlowFields (𝑃) and ancillary variables etc (𝐷) 
+# - read & normalize velocities (𝐷.🔄)
 
 𝑃,𝐷=global_ocean_circulation(k=1,ny=2);
+
+𝐷.🔄(𝑃,𝐷,0.0)
 
 fieldnames(typeof(𝑃))
 

--- a/examples/worldwide/global_ocean_circulation.jl
+++ b/examples/worldwide/global_ocean_circulation.jl
@@ -23,12 +23,7 @@
 using IndividualDisplacements, DataFrames, Statistics, CSV
 
 include(joinpath(dirname(pathof(IndividualDisplacements)),"../examples/helper_functions.jl"))
-
-IndividualDisplacements.get_ecco_variable_if_needed("UVELMASS");
-IndividualDisplacements.get_ecco_variable_if_needed("VVELMASS");
-IndividualDisplacements.get_ecco_variable_if_needed("WVELMASS");
-IndividualDisplacements.get_ecco_variable_if_needed("THETA");
-IndividualDisplacements.get_ecco_variable_if_needed("SALT");
+IndividualDisplacements.get_ecco_velocity_if_needed();
 
 #nb # %% {"slideshow": {"slide_type": "subslide"}, "cell_type": "markdown"}
 # ## 2. Set Up Parameters & Inputs
@@ -38,7 +33,7 @@ IndividualDisplacements.get_ecco_variable_if_needed("SALT");
 # - return FlowFields (𝑃) and ancillary variables etc (𝐷) 
 # - read & normalize velocities (𝐷.🔄)
 
-𝑃,𝐷=global_ocean_circulation(k=0,ny=2);
+𝑃,𝐷=global_ocean_circulation(k=1,ny=2);
 
 𝐷.🔄(𝑃,𝐷,0.0)
 
@@ -60,8 +55,7 @@ p=dirname(pathof(IndividualDisplacements))
 fil=joinpath(p,"../examples/worldwide/global_ocean_circulation.csv")
 df=DataFrame(CSV.File(fil))
 
-z0=4.5
-𝐼=Individuals(𝑃,df.x[1:np],df.y[1:np],fill(z0,np),df.f[1:np])
+𝐼=Individuals(𝑃,df.x[1:np],df.y[1:np],df.f[1:np])
 fieldnames(typeof(𝐼))
 
 #nb # %% {"slideshow": {"slide_type": "subslide"}, "cell_type": "markdown"}
@@ -83,7 +77,7 @@ fieldnames(typeof(𝐼))
 function step!(𝐼::Individuals)
     t_ϵ=𝐼.𝑃.𝑇[2]+eps(𝐼.𝑃.𝑇[2])
     𝐷.🔄(𝐼.𝑃,𝐷,t_ϵ)
-    reset_📌!(𝐼,𝐷.frac,📌ini)
+    #reset_📌!(𝐼,𝐷.frac,📌ini)
     ∫!(𝐼)
 end
 

--- a/examples/worldwide/global_ocean_circulation.jl
+++ b/examples/worldwide/global_ocean_circulation.jl
@@ -38,7 +38,7 @@ IndividualDisplacements.get_ecco_variable_if_needed("SALT");
 # - return FlowFields (𝑃) and ancillary variables etc (𝐷) 
 # - read & normalize velocities (𝐷.🔄)
 
-𝑃,𝐷=global_ocean_circulation(k=1,ny=2);
+𝑃,𝐷=global_ocean_circulation(k=0,ny=2);
 
 𝐷.🔄(𝑃,𝐷,0.0)
 
@@ -60,12 +60,14 @@ p=dirname(pathof(IndividualDisplacements))
 fil=joinpath(p,"../examples/worldwide/global_ocean_circulation.csv")
 df=DataFrame(CSV.File(fil))
 
-𝐼=Individuals(𝑃,df.x[1:np],df.y[1:np],df.f[1:np])
+z0=4.5
+𝐼=Individuals(𝑃,df.x[1:np],df.y[1:np],fill(z0,np),df.f[1:np])
 fieldnames(typeof(𝐼))
 
 #nb # %% {"slideshow": {"slide_type": "subslide"}, "cell_type": "markdown"}
 # - initial integration from time 0 to 0.5 month
 
+📌ini=deepcopy(𝐼.📌)
 𝑇=(0.0,𝐼.𝑃.𝑇[2])
 ∫!(𝐼,𝑇)
 
@@ -75,13 +77,13 @@ fieldnames(typeof(𝐼))
 # In addition, `step!` is defined to provide additional flexibility around `∫!` :
 #
 # - `𝐷.🔄(𝐼.𝑃,t_ϵ)` resets the velocity input streams to bracket t_ϵ=𝐼.𝑃.𝑇[2]+eps(𝐼.𝑃.𝑇[2]) 
-# - `reset_lonlat!(𝐼)` randomly selects a fraction (defined in `setup_global_ocean()`) of the particles and resets their positions before each integration period. This can maintain homogeneous coverage of the Global Ocean by particles.
+# - `reset_xy!(𝐼)` randomly selects a fraction (defined in `setup_global_ocean()`) of the particles and resets their positions before each integration period. This can maintain homogeneous coverage of the Global Ocean by particles.
 # - `∫!(𝐼)` then solves for the individual trajectories over one month, after updating velocity fields (𝐼.u0 etc) if needed, and adds diagnostics to the DataFrame used to record / trace variables along the trajectory (𝐼.tr).
 
 function step!(𝐼::Individuals)
     t_ϵ=𝐼.𝑃.𝑇[2]+eps(𝐼.𝑃.𝑇[2])
     𝐷.🔄(𝐼.𝑃,𝐷,t_ϵ)
-    #reset_lonlat!(𝐼,𝐷)
+    reset_📌!(𝐼,𝐷.frac,📌ini)
     ∫!(𝐼)
 end
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -152,7 +152,7 @@ function Individuals(NT::NamedTuple)
     Individuals{T,ndims(📌)}(📌=📌,🔴=🔴,🆔=🆔,🚄=🚄,∫=∫,🔧=🔧,𝑃=𝑃,𝐷=𝐷,𝑀=𝑀)    
 end
 
-function Individuals(𝐹::𝐹_Array2D,x,y, NT = NamedTuple())
+function Individuals(𝐹::𝐹_Array2D,x,y, NT::NamedTuple = NamedTuple())
     📌=permutedims([[x[i];y[i]] for i in eachindex(x)])
     length(📌)==1 ? 📌=📌[1] : nothing
     T=eltype(📌)
@@ -172,7 +172,7 @@ function Individuals(𝐹::𝐹_Array2D,x,y, NT = NamedTuple())
     Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxy_dt,∫=∫,🔧=🔧)    
 end
 
-function Individuals(𝐹::𝐹_Array3D,x,y,z, NT = NamedTuple())
+function Individuals(𝐹::𝐹_Array3D,x,y,z, NT::NamedTuple = NamedTuple())
     📌=permutedims([[x[i];y[i];z[i]] for i in eachindex(x)])
     length(📌)==1 ? 📌=📌[1] : nothing
     T=eltype(📌)
@@ -197,7 +197,7 @@ function Individuals(𝐹::𝐹_Array3D,x,y,z, NT = NamedTuple())
     Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxyz_dt,∫=∫,🔧=🔧)    
 end
 
-function Individuals(𝐹::𝐹_MeshArray2D,x,y,fid, NT = NamedTuple())
+function Individuals(𝐹::𝐹_MeshArray2D,x,y,fid, NT::NamedTuple = NamedTuple())
     📌=permutedims([[x[i];y[i];fid[i]] for i in eachindex(x)])
     length(📌)==1 ? 📌=📌[1] : nothing
     T=eltype(📌)
@@ -217,7 +217,7 @@ function Individuals(𝐹::𝐹_MeshArray2D,x,y,fid, NT = NamedTuple())
     Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxy_dt!,∫=∫,🔧=🔧)    
 end
 
-function Individuals(𝐹::𝐹_MeshArray3D,x,y,z,fid, NT = NamedTuple())
+function Individuals(𝐹::𝐹_MeshArray3D,x,y,z,fid, NT::NamedTuple = NamedTuple())
     📌=permutedims([[x[i];y[i];z[i];fid[i]] for i in eachindex(x)])
     length(📌)==1 ? 📌=📌[1] : nothing
     T=eltype(📌)

--- a/src/API.jl
+++ b/src/API.jl
@@ -152,63 +152,92 @@ function Individuals(NT::NamedTuple)
     Individuals{T,ndims(📌)}(📌=📌,🔴=🔴,🆔=🆔,🚄=🚄,∫=∫,🔧=🔧,𝑃=𝑃,𝐷=𝐷,𝑀=𝑀)    
 end
 
-function Individuals(𝐹::𝐹_Array2D,x,y)
+function Individuals(𝐹::𝐹_Array2D,x,y, NT = NamedTuple())
     📌=permutedims([[x[i];y[i]] for i in eachindex(x)])
     length(📌)==1 ? 📌=📌[1] : nothing
+    T=eltype(📌)
 
     🔴 = DataFrame(ID=Int[], x=Float64[], y=Float64[], t=Float64[])
+    haskey(NT,:🔴) ? 🔴=NT.🔴 : nothing
+
     🔧 = postprocess_xy
-    T=eltype(📌)
+    haskey(NT,:🔧) ? 🔧=NT.🔧 : nothing
+
     🆔=collect(1:size(📌,2))
+    haskey(NT,:🆔) ? 🆔=NT.🆔 : nothing
+
+    ∫=default_solver
+    haskey(NT,:∫) ? ∫=NT.∫ : nothing
     
-    Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxy_dt,∫=default_solver,🔧=🔧)    
+    Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxy_dt,∫=∫,🔧=🔧)    
 end
 
-function Individuals(𝐹::𝐹_Array3D,x,y,z)
+function Individuals(𝐹::𝐹_Array3D,x,y,z, NT = NamedTuple())
     📌=permutedims([[x[i];y[i];z[i]] for i in eachindex(x)])
     length(📌)==1 ? 📌=📌[1] : nothing
+    T=eltype(📌)
 
     🔴 = DataFrame(ID=Int[], x=Float64[], y=Float64[], z=Float64[], t=Float64[])
+    haskey(NT,:🔴) ? 🔴=NT.🔴 : nothing
+
     function 🔧(sol,𝑄::FlowFields;id=missing,𝑇=missing)
         df=postprocess_xy(sol,𝐹,id=id,𝑇=𝑇)
         z=sol[3,:]
         df.z=z[:]
         return df
     end
-    T=eltype(📌)
+    haskey(NT,:🔧) ? 🔧=NT.🔧 : nothing
+
     🆔=collect(1:size(📌,2))
+    haskey(NT,:🆔) ? 🆔=NT.🆔 : nothing
+
+    ∫=default_solver
+    haskey(NT,:∫) ? ∫=NT.∫ : nothing
     
-    Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxyz_dt,∫=default_solver,🔧=🔧)    
+    Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxyz_dt,∫=∫,🔧=🔧)    
 end
 
-function Individuals(𝐹::𝐹_MeshArray2D,x,y,fid)
+function Individuals(𝐹::𝐹_MeshArray2D,x,y,fid, NT = NamedTuple())
     📌=permutedims([[x[i];y[i];fid[i]] for i in eachindex(x)])
     length(📌)==1 ? 📌=📌[1] : nothing
+    T=eltype(📌)
 
     🔴 = DataFrame(ID=Int[], x=Float64[], y=Float64[], fid=Int64[], t=Float64[])
+    haskey(NT,:🔴) ? 🔴=NT.🔴 : nothing
+
     🔧 = postprocess_MeshArray
+    haskey(NT,:🔧) ? 🔧=NT.🔧 : nothing
 
-    T=eltype(📌)
     🆔=collect(1:size(📌,2))
+    haskey(NT,:🆔) ? 🆔=NT.🆔 : nothing
 
-    Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxy_dt!,∫=default_solver,🔧=🔧)    
+    ∫=default_solver
+    haskey(NT,:∫) ? ∫=NT.∫ : nothing
+
+    Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxy_dt!,∫=∫,🔧=🔧)    
 end
 
-function Individuals(𝐹::𝐹_MeshArray3D,x,y,z,fid)
+function Individuals(𝐹::𝐹_MeshArray3D,x,y,z,fid, NT = NamedTuple())
     📌=permutedims([[x[i];y[i];z[i];fid[i]] for i in eachindex(x)])
     length(📌)==1 ? 📌=📌[1] : nothing
+    T=eltype(📌)
 
     🔴 = DataFrame(ID=Int[], x=Float64[], y=Float64[], z=Float64[], fid=Int64[], t=Float64[])
+    haskey(NT,:🔴) ? 🔴=NT.🔴 : nothing
+
     function 🔧(sol,𝑄::FlowFields;id=missing,𝑇=missing)
         df=postprocess_MeshArray(sol,𝐹,id=id,𝑇=𝑇)
         z=[sol[1,i,j][1] for i in 1:size(sol,2), j in 1:size(sol,3)]
         df.z=z[:]
         return df
     end
+    haskey(NT,:🔧) ? 🔧=NT.🔧 : nothing
 
-    T=eltype(📌)
     🆔=collect(1:size(📌,2))
+    haskey(NT,:🆔) ? 🆔=NT.🆔 : nothing
+
     ∫=default_solver
+    haskey(NT,:∫) ? ∫=NT.∫ : nothing
 
     Individuals{T,ndims(📌)}(𝑃=𝐹,📌=📌,🔴=🔴,🆔=🆔,🚄=dxyz_dt!,∫=∫,🔧=🔧)    
 end

--- a/src/API.jl
+++ b/src/API.jl
@@ -201,7 +201,7 @@ function Individuals(𝐹::𝐹_MeshArray3D,x,y,z,fid)
     🔴 = DataFrame(ID=Int[], x=Float64[], y=Float64[], z=Float64[], fid=Int64[], t=Float64[])
     function 🔧(sol,𝑄::FlowFields;id=missing,𝑇=missing)
         df=postprocess_MeshArray(sol,𝐹,id=id,𝑇=𝑇)
-        z=sol[3,:]
+        z=[sol[1,i,j][1] for i in 1:size(sol,2), j in 1:size(sol,3)]
         df.z=z[:]
         return df
     end

--- a/src/IndividualDisplacements.jl
+++ b/src/IndividualDisplacements.jl
@@ -20,7 +20,8 @@ export FlowFields, convert_to_FlowFields
 export 𝐹_Array3D, 𝐹_Array2D, 𝐹_MeshArray3D, 𝐹_MeshArray2D
 export dxy_dt!, dxy_dt, dxyz_dt!, dxyz_dt, dxy_dt_CyclicArray, dxy_dt_replay
 export postprocess_MeshArray, add_lonlat!, postprocess_xy, interp_to_xy
-export nearest_to_xy, randn_lonlat, interp_to_lonlat, gcdist
+export nearest_to_xy, randn_lonlat, interp_to_lonlat
+export gcdist, stproj, stproj_inv
 export read_drifters, read_mds, read_velocities
 
 end # module

--- a/src/data_wrangling.jl
+++ b/src/data_wrangling.jl
@@ -67,26 +67,19 @@ end
 Add lon & lat to dataframe using "exchanged" XC, YC
 """
 function add_lonlat!(df::DataFrame,XC,YC)
-    x=df[!,:x];
-    y=df[!,:y];
-    f=Int.(df[!,:fid]);
-    dx,dy=(x - floor.(x) .+ 0.5,y - floor.(y) .+ 0.5);
-    i_c = Int32.(floor.(x)) .+ 1;
-    j_c = Int32.(floor.(y)) .+ 1;
+    x = cosd.(YC) * cosd.(XC)
+    y = cosd.(YC) * sind.(XC)
+    z = sind.(YC)
 
-    lon=zeros(length(x),4)
-    [lon[k,:]=XC[f[k]][i_c[k]:i_c[k]+1,j_c[k]:j_c[k]+1][:] for k in 1:length(i_c)]
-    lat=zeros(length(x),4)
-    [lat[k,:]=YC[f[k]][i_c[k]:i_c[k]+1,j_c[k]:j_c[k]+1][:] for k in 1:length(i_c)]
-
-    k=findall(vec(maximum(lon,dims=2)-minimum(lon,dims=2)) .> 180.0)
-    tmp=view(lon,k,:)
-    tmp[findall(tmp.<0.0)]=tmp[findall(tmp.<0.0)] .+ 360.0
-
-    df.lon=(1.0 .-dx).*(1.0 .-dy).*lon[:,1]+dx.*(1.0 .-dy).*lon[:,2] +
-         (1.0 .-dx).*dy.*lon[:,3]+dx.*dy.*lon[:,4]
-    df.lat=(1.0 .-dx).*(1.0 .-dy).*lat[:,1]+dx.*(1.0 .-dy).*lat[:,2] +
-         (1.0 .-dx).*dy.*lat[:,3]+dx.*dy.*lat[:,4]
+    df.lon=0*df.x
+    df.lat=0*df.x
+    for i in eachindex(df.lon)
+        xx=interp_to_xy(df.x[i],df.y[i],df.fid[i],x)
+        yy=interp_to_xy(df.x[i],df.y[i],df.fid[i],y)
+        zz=interp_to_xy(df.x[i],df.y[i],df.fid[i],z)
+        df.lat[i] = asind(zz/sqrt(xx^2+yy^2+zz^2))
+        df.lon[i] = atand(yy, xx)
+    end
 
     return df
 end
@@ -208,4 +201,82 @@ function interp_to_xy(df::DataFrame,Zin::MeshArray)
 
     return (1.0 .-dx).*(1.0 .-dy).*Z[:,1]+dx.*(1.0 .-dy).*Z[:,2] +
            (1.0 .-dx).*dy.*Z[:,3]+dx.*dy.*Z[:,4]
+end
+
+function interp_to_xy(x,y,f,Zin::MeshArray)
+    dx,dy=(x - floor(x) + 0.5,y - floor(y) + 0.5)
+    i_c = Int(floor(x)) + 1
+    j_c = Int(floor(y)) + 1
+    ff=Int(f)
+
+    return (1.0-dx)*(1.0-dy)*Zin[ff][i_c,j_c] +
+    dx*(1.0-dy)*Zin[ff][i_c+1,j_c] +
+    (1.0-dx)*dy*Zin[ff][i_c,j_c+1] +
+    dx*dy*Zin[ff][i_c+1,j_c+1]
+end
+
+"""
+    stproj(XC,YC;XC0=0.0,YC0=90.0)
+
+Apply to XC,YC (longitude, latitude) the stereographic projection
+which would put XC0,YC0 (longitude, latitude) at x,y=0,0
+"""
+function stproj(XC,YC,XC0=0.0,YC0=90.0)
+
+# compute spherical coordinates:
+phi=pi/180*XC; theta=pi/180*(90-YC);
+phi0=pi/180*XC0; theta0=pi/180*(90-YC0);
+
+# compute cartesian coordinates:
+x=sin(theta)*cos(phi)
+y=sin(theta)*sin(phi)
+z=cos(theta)
+
+# bring chosen longitude to x>0,y=0:
+xx=cos(phi0)*x+sin(phi0)*y
+yy=-sin(phi0)*x+cos(phi0)*y
+zz=z
+# bring chosen point to South Pole:
+x=cos(theta0)*xx-sin(theta0)*zz
+y=yy
+z=sin(theta0)*xx+cos(theta0)*zz
+
+# stereographic projection from South Pole:
+xx=x/(1+z)
+yy=y/(1+z)
+
+return xx,yy
+end
+
+"""
+    stproj_inv(xx,yy;XC0=0.0,YC0=90.0)
+
+Apply to xx,yy (stereographic projection coordinates) the reverse 
+of the stereographic projection which puts XC0,YC0 (longitude, 
+latitude) at x,y=0,0
+"""
+function stproj_inv(xx,yy,XC0=0.0,YC0=90.0)
+    phi0=pi/180*XC0; theta0=pi/180*(90-YC0);
+
+    # Reverse stereographic projection from North Pole:
+    (x,y,z)=2*[xx yy (1-xx^2-yy^2)/2]./(1+xx^2+yy^2)
+
+    # bring chosen point back from South Pole:
+    xx=cos(theta0)*x+sin(theta0)*z
+    yy=y
+    zz=-sin(theta0)*x+cos(theta0)*z
+
+    # bring chosen longitude back from x>0,y=0:
+    x=cos(phi0)*xx-sin(phi0)*yy
+    y=sin(phi0)*xx+cos(phi0)*yy
+    z=zz
+
+    # compute spherical coordinates:
+    theta=atan(sqrt(x^2+y^2)/z)
+    phi=atan(y, x)
+    
+    XC=180/pi*phi
+    theta>=0 ? YC=90-180/pi*theta : YC=-90-180/pi*theta
+
+    return XC,YC
 end

--- a/src/read.jl
+++ b/src/read.jl
@@ -128,6 +128,12 @@ function get_ecco_variable_if_needed(v::String)
     !isdir(pth*v) ? get_from_dataverse(lst,v,pth) : nothing
 end
 
+function get_ecco_velocity_if_needed()
+    get_ecco_variable_if_needed("UVELMASS")
+    get_ecco_variable_if_needed("VVELMASS")
+    get_ecco_variable_if_needed("WVELMASS")
+end
+
 """
     get_occa_velocity_if_needed()
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -117,17 +117,15 @@ function read_mds(filRoot::String,x::MeshArray)
 end
 
 """
-    get_ecco_velocity_if_needed()
+    get_ecco_variable_if_needed(v::String)
 
-Download `MITgcm` transport output to `examples/nctiles_climatology` if needed
+Download ECCO output for variable `v` to `examples/nctiles_climatology` if needed
 """
-function get_ecco_velocity_if_needed()
+function get_ecco_variable_if_needed(v::String)
     p=dirname(pathof(OceanStateEstimation))
     lst=joinpath(p,"../examples/nctiles_climatology.csv")
     pth=ECCOclim_path
-    !isdir(pth*"UVELMASS") ? get_from_dataverse(lst,"UVELMASS",pth) : nothing
-    !isdir(pth*"VVELMASS") ? get_from_dataverse(lst,"VVELMASS",pth) : nothing
-    !isdir(pth*"WVELMASS") ? get_from_dataverse(lst,"WVELMASS",pth) : nothing
+    !isdir(pth*v) ? get_from_dataverse(lst,v,pth) : nothing
 end
 
 """


### PR DESCRIPTION
- add stereographic projection `stproj` and inverse function `stproj_inv` (useful for plotting and mapping onto e.g. cube sphere)
- fix `add_lonlat!` at high latitudes (average cartesian coordinates via `interp_xy` -- not Lon,lat)
- add `reset_📌!` that draws from 📌 passed as argument to replace `reset_lonlat!`
- fix `init_global_randn`
- rename `set_up_𝑃`, `update_𝑃` as `set_up_FlowFields`, `update_FlowFields!` and streamline 
- add three-dimensional version of `update_FlowFields!`
- move `update_FlowFields!` call outside of `set_up_𝑃` (to `global_ocean_circulation.jl`)
- add customization option to constructors via `NT::NamedTuple = NamedTuple()` optional argument