### PR TITLE
set safetycopy to false by default for EnsembleProblem

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -127,11 +127,11 @@ end
 
 default_solver(prob) = solve(prob,Tsit5(),reltol=1e-8,abstol=1e-8)
 
-function ensemble_solver(prob;solver=Tsit5(),reltol=1e-8,abstol=1e-8)
+function ensemble_solver(prob;solver=Tsit5(),reltol=1e-8,abstol=1e-8,safetycopy=false)
 	u0 = prob.u0
 	prob_func(prob,i,repeat) = remake(prob,u0=u0[i])
 	indiv_prob = ODEProblem(prob.f,u0[1],prob.tspan,prob.p)
-	ensemble_prob = EnsembleProblem(indiv_prob,prob_func=prob_func)
+	ensemble_prob = EnsembleProblem(indiv_prob,prob_func=prob_func,safetycopy=safetycopy)
 	solve(ensemble_prob, solver, reltol=reltol, abstol=abstol, trajectories=length(u0))
 end
 


### PR DESCRIPTION
With `safetycopy=true` by default, an error occurs when running `examples/worldwide/global_ocean_circulation.jl` within `Pluto.jl` :

`nested task error: deepcopy of Modules not supported`

Interestingly, the error would not occur outside Pluto (e.g. in the jldoctest of the same example). 